### PR TITLE
Add create ui for roadmaps

### DIFF
--- a/src/components/ExtendableList.js
+++ b/src/components/ExtendableList.js
@@ -9,7 +9,7 @@ const ExtendableList = props => {
       {props.items.map((value, index) => {
         return (
           <div className="row" key={props.pIndex * 100 + index}>
-            <label className="col-sm-2 label-on-left">{props.inputLabels ? props.inputLabels[index] : `${props.childCategory} ${index + 1}`}</label>
+            <label className="col-sm-2 label-on-left">{props.inputLabels ? props.inputLabels[index] : `${props.childCategorySingular} ${index + 1}`}</label>
             <div className="col-sm-10">
               <div className="form-group label-floating is-empty">
                 <Input
@@ -24,7 +24,7 @@ const ExtendableList = props => {
         )
       })}
 
-      {props.addItemList && <button type="button" onClick={() => props.addItemList(props.childCategory, props.pIndex)} className="btn btn-success pull-right"><i class="material-icons">add</i>{` Add ${props.childCategory}`}</button>}
+      {props.addItemList && <button type="button" onClick={() => props.addItemList(props.childCategory, props.pIndex)} className="btn btn-success"><i class="material-icons">add</i>{` Add ${props.childCategory}`}</button>}
       <div>&nbsp;</div>
     </div>
   )

--- a/src/components/ExtendableList.js
+++ b/src/components/ExtendableList.js
@@ -24,7 +24,7 @@ const ExtendableList = props => {
         )
       })}
 
-      {props.addItemList && <button type="button" onClick={() => props.addItemList(props.childCategory, props.pIndex)} className="btn btn-success"><i class="material-icons">add</i>{` Add ${props.childCategory}`}</button>}
+      {props.addItemList && <button type="button" onClick={() => props.addItemList(props.childCategory, props.pIndex)} className="btn btn-success"><i className="material-icons">add</i>{` Add ${props.childCategory}`}</button>}
       <div>&nbsp;</div>
     </div>
   )

--- a/src/components/ExtendableList.js
+++ b/src/components/ExtendableList.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import Input from './Input';
+
+const ExtendableList = props => {
+  return (
+    <div>
+      <h4 className="text-default">{props.childCategory} for <b>{props.parentCategory}</b></h4>
+
+      {props.items.map((value, index) => {
+        return (
+          <div className="row" key={props.pIndex * 100 + index}>
+            <label className="col-sm-2 label-on-left">{`${props.childCategory} ${index + 1}`}</label>
+            <div className="col-sm-10">
+              <div className="form-group label-floating is-empty">
+                <Input
+                  onChange={(newValue) => props.updateInputList(newValue, `${props.childCategory}`, props.pIndex, index)}
+                  text={value}
+                  placeholder={props.placeholder}
+                  helpBlock={props.helpBlock}
+                />
+              </div>
+            </div>
+          </div>
+        )
+      })}
+
+      <button type="button" onClick={() => props.addItemList(props.childCategory, props.pIndex)} className="btn btn-success pull-right"><i class="material-icons">add</i>{` Add ${props.childCategory}`}</button>
+      <div>&nbsp;</div>
+    </div>
+  )
+}
+
+export default ExtendableList

--- a/src/components/ExtendableList.js
+++ b/src/components/ExtendableList.js
@@ -9,7 +9,7 @@ const ExtendableList = props => {
       {props.items.map((value, index) => {
         return (
           <div className="row" key={props.pIndex * 100 + index}>
-            <label className="col-sm-2 label-on-left">{`${props.childCategory} ${index + 1}`}</label>
+            <label className="col-sm-2 label-on-left">{props.inputLabels ? props.inputLabels[index] : `${props.childCategory} ${index + 1}`}</label>
             <div className="col-sm-10">
               <div className="form-group label-floating is-empty">
                 <Input
@@ -24,7 +24,7 @@ const ExtendableList = props => {
         )
       })}
 
-      <button type="button" onClick={() => props.addItemList(props.childCategory, props.pIndex)} className="btn btn-success pull-right"><i class="material-icons">add</i>{` Add ${props.childCategory}`}</button>
+      {props.addItemList && <button type="button" onClick={() => props.addItemList(props.childCategory, props.pIndex)} className="btn btn-success pull-right"><i class="material-icons">add</i>{` Add ${props.childCategory}`}</button>}
       <div>&nbsp;</div>
     </div>
   )

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -49,7 +49,8 @@ export class Input extends Component {
             placeholder={this.props.placeholder}
             value={this.props.text}
             disabled={(this.props.type === 'disabled') ? true : false}
-            />
+          />
+          <span className="help-block">{(this.props.helpBlock) ? this.props.helpBlock : ``}</span>
         </div>
       )
     } else if (valid === false && ((this.props.text === null || this.props.text === "") === false || this.props.submitted)) {
@@ -63,7 +64,8 @@ export class Input extends Component {
             placeholder={this.props.placeholder}
             value={this.props.text}
             disabled={(this.props.type === 'disabled') ? true : false}
-            />
+          />
+          <span className="help-block">{(this.props.helpBlock) ? this.props.helpBlock : ``}</span>
           {this.drawErrorMessage()}
         </div>
       )
@@ -77,7 +79,8 @@ export class Input extends Component {
             className="form-control"
             placeholder={this.props.placeholder}
             value={this.props.text}
-            />
+          />
+          <span className="help-block">{(this.props.helpBlock) ? this.props.helpBlock : ``}</span>
         </div>
       )
     }

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -7,6 +7,7 @@ import * as Actions from '../actions/rubric';
 import mixpanel from 'mixpanel-browser';
 import Input from './Input';
 import ExtendableList from './ExtendableList';
+import serverPath from '../paths';
 
 class RubricEdit extends Component {
   // Needed for this.state to correctly reference state when function is passed down
@@ -55,12 +56,12 @@ class RubricEdit extends Component {
       name: `${firstName} ${lastName}'s New Roadmap`
     }
 
-    if (pathname.includes('rubric/new')) {
-      this.setState({needsNewRubric: true})
-      createNewRubric(userId, newRubric)
-    } else {
-      getRubricById(rubricId);
-    }
+    // if (pathname.includes('rubric/new')) {
+    //   this.setState({needsNewRubric: true})
+    //   createNewRubric(userId, newRubric)
+    // } else {
+    //   getRubricById(rubricId);
+    // }
   }
 
   componentDidMount() {
@@ -105,6 +106,37 @@ class RubricEdit extends Component {
   }
 
   submitForm(e) {
+    const rubric = {
+      name: this.state.rubric.name,
+      description: this.state.rubric.description,
+      levelOne: this.state.rubric.levelOne,
+      levelTwo: this.state.rubric.levelTwo,
+      levelThree: this.state.rubric.levelThree,
+      levelFour: this.state.rubric.levelFour,
+    }
+
+    let config = {
+      method: 'POST',
+      body: JSON.stringify(rubric),
+      headers: {
+        'Accept': 'application/json, text/plain, */*',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + localStorage.getItem('token')
+      }
+    }
+
+    const userId = localStorage.getItem('userId')
+    fetch(`${serverPath}/users/${userId}/rubrics/create`, config).then((res) => {
+      if (res.status !== 200) {
+        return Promise.reject(`Could not save user`)
+      }
+      return res.json();
+    }).then((json) => {
+      this.props.history.push(`/users/${userId}/rubrics`)
+    }).catch(err => {
+      console.log("There was an error: " + err)
+    });
+
     e.preventDefault()
   }
 
@@ -244,6 +276,7 @@ class RubricEdit extends Component {
                       helpBlock={"What is a skill to have to be knowledgeable in this competency?"}
                       pIndex={index}
                       addItemList={this.addItemList}
+                      key={index}
                     />
                   )
                 })}
@@ -259,11 +292,12 @@ class RubricEdit extends Component {
                       placeholder={"e.g. Knowing common elements (Competant), Knowing all elements (Proficient)..."}
                       helpBlock={"How would you evaluate this skill at this level?"}
                       pIndex={index}
+                      key={index}
                     />
                   )
                 })}
 
-                <button type="submit" className="btn btn-success pull-right"><i class="material-icons">done</i> Submit Rubric</button>
+                <button type="submit" className="btn btn-success pull-right"><i className="material-icons">done</i> Submit Rubric</button>
                 <div className="clearfix"></div>
               </form>
 

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -107,12 +107,17 @@ class RubricEdit extends Component {
 
   submitForm(e) {
     const rubric = {
-      name: this.state.rubric.name,
-      description: this.state.rubric.description,
-      levelOne: this.state.rubric.levelOne,
-      levelTwo: this.state.rubric.levelTwo,
-      levelThree: this.state.rubric.levelThree,
-      levelFour: this.state.rubric.levelFour,
+      rubric: {
+        name: this.state.rubric.name,
+        description: this.state.rubric.description,
+        levelOne: this.state.rubric.levelOne,
+        levelTwo: this.state.rubric.levelTwo,
+        levelThree: this.state.rubric.levelThree,
+        levelFour: this.state.rubric.levelFour,
+      },
+      competencies: this.state.rubric.Competencies,
+      skills: this.state.rubric.Skills,
+      evaluations: this.state.rubric.Evaluations
     }
 
     let config = {
@@ -126,7 +131,7 @@ class RubricEdit extends Component {
     }
 
     const userId = localStorage.getItem('userId')
-    fetch(`${serverPath}/users/${userId}/rubrics/create`, config).then((res) => {
+    fetch(`${serverPath}/users/${userId}/completeRubrics/create`, config).then((res) => {
       if (res.status !== 200) {
         return Promise.reject(`Could not save user`)
       }

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -111,6 +111,8 @@ class RubricEdit extends Component {
     const { name, id, userId, iconName, iconColor, description, levelOne, levelTwo, levelThree, levelFour } = rubric
     const firstName = localStorage.getItem('firstName')
     const lastName = localStorage.getItem('lastName')
+    const allSkills = this.state.rubric.Skills.reduce((acc, skillGroup) => [...acc, ...skillGroup])
+    const evalLabels = [this.state.rubric.levelOne, this.state.rubric.levelTwo, this.state.rubric.levelThree, this.state.rubric.levelFour]
     return (
       <div className="col-sm-10 col-md-9 col-lg-8">
         {/* {this.redirect(isFetching, needsNewRubric, userId, id)} */}
@@ -224,7 +226,7 @@ class RubricEdit extends Component {
                 pIndex={0}
                 addItemList={this.addItemList}
               />
-              {this.state.rubric.Competencies[0].map((value, index) => {
+              {this.state.rubric.Competencies[0].map((competency, index) => {
                 return (
                   <ExtendableList
                     childCategory={"Skills"}
@@ -235,6 +237,20 @@ class RubricEdit extends Component {
                     helpBlock={"What is a skill to have to be knowledgeable in this competency?"}
                     pIndex={index}
                     addItemList={this.addItemList}
+                  />
+                )
+              })}
+              {allSkills.map((skill, index) => {
+                return (
+                  <ExtendableList
+                    childCategory={"Evaluations"}
+                    inputLabels={evalLabels}
+                    parentCategory={allSkills[index]}
+                    items={this.state.rubric.Evaluations[index]}
+                    updateInputList={this.updateInputList}
+                    placeholder={"e.g. Knowing common elements (Competant), Knowing all elements (Proficient)..."}
+                    helpBlock={"How would you evaluate this skill at this level?"}
+                    pIndex={index}
                   />
                 )
               })}

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -12,7 +12,18 @@ class RubricEdit extends Component {
   state = {
     needsNewRubric: false,
     nameInput: "",
+    rubric: {
+      id: '',
+      name: '',
+      description: '',
+      userId: '',
+      levelOne: '',
+      levelTwo: '',
+      levelThree: '',
+      levelFour: '',
+    }
   }
+
   // 1. Check to see if it is in 'edit' or 'new' mode
   // 2. Map state to props
   // 3. Render the component
@@ -51,9 +62,11 @@ class RubricEdit extends Component {
     this.props.history.goBack()
   }
 
-  updateNameInput(e) {
-    e.preventDefault();
-    this.props.updateNameInput(e.target.value);
+  updateNameInput(value, key) {
+    console.log(key, value)
+    // console.log(this.props)
+    // this.props.updateNameInput(e);
+    this.setState({...this.state, rubric: {...this.state.rubric, [key]: value}})
   }
 
   render() {
@@ -82,7 +95,12 @@ class RubricEdit extends Component {
                 <label className="col-sm-2 label-on-left">Name (Title)</label>
                 <div className="col-sm-10">
                   <div className="form-group label-floating is-empty">
-                    <Input onChange={this.updateNameInput.bind(this)} text={ name === `${firstName} ${lastName}'s New Roadmap` ? `` : name } placeholder="e.g. Code Review..." autoFocus={true}/>
+                    <Input
+                      text={this.state.rubric.name}
+                      onChange={(newValue) => this.updateNameInput(newValue, "name")}
+                      placeholder="e.g. Code Review..."
+                      autoFocus={true}
+                    />
                     <span className="help-block">What skillset does this roadmap assess/achieve?</span>
                   </div>
                 </div>
@@ -94,7 +112,13 @@ class RubricEdit extends Component {
                 <label className="col-sm-2 label-on-left">Description</label>
                 <div className="col-sm-10">
                   <div className="form-group label-floating is-empty">
-                    <textarea className="form-control text-info" onChange={e => {e.preventDefault(); console.log(e.target.value);}} rows="5" text={description} placeholder={`e.g. "A comprehensive roadmap for getting a job as a data scientist. I made this roadmap because..."`}></textarea>
+                    <textarea
+                      className="form-control text-info"
+                      onChange={(e) => this.updateNameInput(e.target.value, "description")}
+                      rows="5"
+                      text={this.state.rubric.description}
+                      placeholder={`e.g. "A comprehensive roadmap for getting a job as a data scientist. I made this roadmap because..."`}
+                    ></textarea>
                     <span className="help-block">Enter any detailed information about you'd like to share about this roadmap.  What inspired you to make it?  Why are you're qualified to make it?  What a person could expect to achieve by completing it?</span>
                   </div>
                 </div>
@@ -106,7 +130,11 @@ class RubricEdit extends Component {
                 <label className="col-sm-2 label-on-left">Level 1</label>
                 <div className="col-sm-10">
                   <div className="form-group label-floating is-empty">
-                    <Input onChange={this.updateNameInput.bind(this)} text={levelOne} placeholder="e.g. Unsatisfactory, Beginner, Initial..." />
+                    <Input
+                      onChange={(newValue) => this.updateNameInput(newValue, "levelOne")}
+                      text={this.state.rubric.levelOne}
+                      placeholder="e.g. Unsatisfactory, Beginner, Initial..."
+                    />
                     <span className="help-block">How would you describe the initial level of mastery of your Roadmap?</span>
                   </div>
                 </div>
@@ -115,7 +143,11 @@ class RubricEdit extends Component {
                 <label className="col-sm-2 label-on-left">Level 2</label>
                 <div className="col-sm-10">
                   <div className="form-group label-floating is-empty">
-                    <Input onChange={this.updateNameInput.bind(this)} text={levelTwo} placeholder="e.g. Competant, Intermediate, Approaching..." />
+                    <Input
+                      onChange={(newValue) => this.updateNameInput(newValue, "levelTwo")}
+                      text={this.state.rubric.levelTwo}
+                      placeholder="e.g. Competant, Intermediate, Approaching..."
+                    />
                     <span className="help-block">How would you describe the second level of mastery of your Roadmap?</span>
                   </div>
                 </div>
@@ -124,7 +156,11 @@ class RubricEdit extends Component {
                 <label className="col-sm-2 label-on-left">Level 3</label>
                 <div className="col-sm-10">
                   <div className="form-group label-floating is-empty">
-                    <Input onChange={this.updateNameInput.bind(this)} text={levelThree} placeholder="e.g. Proficient, Advanced, Overtaking..." />
+                    <Input
+                      onChange={(newValue) => this.updateNameInput(newValue, "levelThree")}
+                      text={this.state.rubric.levelThree}
+                      placeholder="e.g. Proficient, Advanced, Overtaking..."
+                    />
                     <span className="help-block">How would you describe the third level of mastery of your Roadmap?</span>
                   </div>
                 </div>
@@ -133,7 +169,11 @@ class RubricEdit extends Component {
                 <label className="col-sm-2 label-on-left">Level 4</label>
                 <div className="col-sm-10">
                   <div className="form-group label-floating is-empty">
-                    <Input onChange={this.updateNameInput.bind(this)} text={levelFour} placeholder="e.g. Professional, Expert, Innovating..." />
+                    <Input
+                      onChange={(newValue) => this.updateNameInput(newValue, "levelFour")}
+                      text={this.state.rubric.levelFour}
+                      placeholder="e.g. Professional, Expert, Innovating..."
+                    />
                     <span className="help-block">How would you describe the last level of mastery of your Roadmap?</span>
                   </div>
                 </div>

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -93,6 +93,16 @@ class RubricEdit extends Component {
     const updatedList = [...this.state.rubric[key]]
     updatedList[pIndex].push('')
     this.setState({...this.state, rubric: {...this.state.rubric, [key]: updatedList}})
+
+    if (key === "Competencies") {
+      const skillList = [...this.state.rubric["Skills"], ['']]
+      const evalList = [...this.state.rubric["Evaluations"], ['', '', '', '']]
+      this.setState({...this.state, rubric: {...this.state.rubric, ["Skills"]: skillList, ["Evaluations"]: evalList}})
+    }
+    if (key === "Skills") {
+      const evalList = [...this.state.rubric["Evaluations"], ['', '', '', '']]
+      this.setState({...this.state, rubric: {...this.state.rubric, ["Evaluations"]: evalList}})
+    }
   }
 
   render() {
@@ -214,6 +224,20 @@ class RubricEdit extends Component {
                 pIndex={0}
                 addItemList={this.addItemList}
               />
+              {this.state.rubric.Competencies[0].map((value, index) => {
+                return (
+                  <ExtendableList
+                    childCategory={"Skills"}
+                    parentCategory={this.state.rubric.Competencies[0][index]}
+                    items={this.state.rubric.Skills[index]}
+                    updateInputList={this.updateInputList}
+                    placeholder={"e.g. Body Language (when Speaking), Citing (when Writing)..."}
+                    helpBlock={"What is a skill to have to be knowledgeable in this competency?"}
+                    pIndex={index}
+                    addItemList={this.addItemList}
+                  />
+                )
+              })}
             </div>
           </div>
         </div>

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -37,6 +37,7 @@ class RubricEdit extends Component {
     this.updateNameInput = this.updateNameInput.bind(this)
     this.updateInputList = this.updateInputList.bind(this)
     this.addItemList = this.addItemList.bind(this)
+    this.submitForm = this.submitForm.bind(this)
   }
 
   // 1. Check to see if it is in 'edit' or 'new' mode
@@ -78,8 +79,6 @@ class RubricEdit extends Component {
   }
 
   updateNameInput(value, key) {
-    // console.log(this.props)
-    // this.props.updateNameInput(e);
     this.setState({...this.state, rubric: {...this.state.rubric, [key]: value}})
   }
 
@@ -105,6 +104,10 @@ class RubricEdit extends Component {
     }
   }
 
+  submitForm(e) {
+    e.preventDefault()
+  }
+
   render() {
     const { needsNewRubric } = this.state
     const { isFetching, rubric } = this.props
@@ -116,7 +119,7 @@ class RubricEdit extends Component {
     return (
       <div className="col-sm-10 col-md-9 col-lg-8">
         {/* {this.redirect(isFetching, needsNewRubric, userId, id)} */}
-        <button onClick={this.goBack.bind(this)} style={{padding: '0'}} className="btn btn-lg btn-info btn-round btn-simple">
+        <button onClick={this.goBack} style={{padding: '0'}} className="btn btn-lg btn-info btn-round btn-simple">
           <i className="material-icons">arrow_back_ios</i> back
         </button>
         <div className="card">
@@ -127,133 +130,143 @@ class RubricEdit extends Component {
             <h2 className={`card-title text-${iconColor}`}><small>Edit <b>{name}</b> Roadmap...</small></h2>
             <div className="form-horizontal">
 
+              <form onSubmit={this.submitForm}>
+                <h4>What skillset does this roadmap assess/achieve?</h4>
+                <div className="row">
+                  <label className="col-sm-2 label-on-left">Name (Title)</label>
+                  <div className="col-sm-10">
+                    <div className="form-group label-floating is-empty">
+                      <Input
+                        text={this.state.rubric.name}
+                        onChange={(newValue) => this.updateNameInput(newValue, "name")}
+                        placeholder="e.g. Code Review..."
+                        autoFocus={true}
+                        helpBlock="What skillset does this roadmap assess/achieve?"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div>&nbsp;</div>
 
-              <h4>What skillset does this roadmap assess/achieve?</h4>
-              <div className="row">
-                <label className="col-sm-2 label-on-left">Name (Title)</label>
-                <div className="col-sm-10">
-                  <div className="form-group label-floating is-empty">
-                    <Input
-                      text={this.state.rubric.name}
-                      onChange={(newValue) => this.updateNameInput(newValue, "name")}
-                      placeholder="e.g. Code Review..."
-                      autoFocus={true}
-                      helpBlock="What skillset does this roadmap assess/achieve?"
-                    />
+                <h4>How would you describe this roadmap in more detail?</h4>
+                <div className="row">
+                  <label className="col-sm-2 label-on-left">Description</label>
+                  <div className="col-sm-10">
+                    <div className="form-group label-floating is-empty">
+                      <textarea
+                        className="form-control text-info"
+                        onChange={(e) => this.updateNameInput(e.target.value, "description")}
+                        rows="5"
+                        text={this.state.rubric.description}
+                        placeholder={`e.g. "A comprehensive roadmap for getting a job as a data scientist. I made this roadmap because..."`}
+                      ></textarea>
+                      <span className="help-block">Enter any detailed information about you'd like to share about this roadmap.  What inspired you to make it?  Why are you're qualified to make it?  What a person could expect to achieve by completing it?</span>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div>&nbsp;</div>
+                <div>&nbsp;</div>
 
-              <h4>How would you describe this roadmap in more detail?</h4>
-              <div className="row">
-                <label className="col-sm-2 label-on-left">Description</label>
-                <div className="col-sm-10">
-                  <div className="form-group label-floating is-empty">
-                    <textarea
-                      className="form-control text-info"
-                      onChange={(e) => this.updateNameInput(e.target.value, "description")}
-                      rows="5"
-                      text={this.state.rubric.description}
-                      placeholder={`e.g. "A comprehensive roadmap for getting a job as a data scientist. I made this roadmap because..."`}
-                    ></textarea>
-                    <span className="help-block">Enter any detailed information about you'd like to share about this roadmap.  What inspired you to make it?  Why are you're qualified to make it?  What a person could expect to achieve by completing it?</span>
+                <h4 className="text-default">Describe the 4 different levels of skill for <b>{name}</b></h4>
+                <div className="row">
+                  <label className="col-sm-2 label-on-left">Level 1</label>
+                  <div className="col-sm-10">
+                    <div className="form-group label-floating is-empty">
+                      <Input
+                        onChange={(newValue) => this.updateNameInput(newValue, "levelOne")}
+                        text={this.state.rubric.levelOne}
+                        placeholder="e.g. Unsatisfactory, Beginner, Initial..."
+                        helpBlock="How would you describe the initial level of mastery of your Roadmap?"
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div>&nbsp;</div>
+                <div className="row">
+                  <label className="col-sm-2 label-on-left">Level 2</label>
+                  <div className="col-sm-10">
+                    <div className="form-group label-floating is-empty">
+                      <Input
+                        onChange={(newValue) => this.updateNameInput(newValue, "levelTwo")}
+                        text={this.state.rubric.levelTwo}
+                        placeholder="e.g. Competant, Intermediate, Approaching..."
+                        helpBlock="How would you describe the second level of mastery of your Roadmap?"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="row">
+                  <label className="col-sm-2 label-on-left">Level 3</label>
+                  <div className="col-sm-10">
+                    <div className="form-group label-floating is-empty">
+                      <Input
+                        onChange={(newValue) => this.updateNameInput(newValue, "levelThree")}
+                        text={this.state.rubric.levelThree}
+                        placeholder="e.g. Proficient, Advanced, Overtaking..."
+                        helpBlock="How would you describe the third level of mastery of your Roadmap?"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="row">
+                  <label className="col-sm-2 label-on-left">Level 4</label>
+                  <div className="col-sm-10">
+                    <div className="form-group label-floating is-empty">
+                      <Input
+                        onChange={(newValue) => this.updateNameInput(newValue, "levelFour")}
+                        text={this.state.rubric.levelFour}
+                        placeholder="e.g. Professional, Expert, Innovating..."
+                        helpBlock="How would you describe the last level of mastery of your Roadmap?"
+                      />
+                    </div>
+                  </div>
+                </div>
 
-              <h4 className="text-default">Describe the 4 different levels of skill for <b>{name}</b></h4>
-              <div className="row">
-                <label className="col-sm-2 label-on-left">Level 1</label>
-                <div className="col-sm-10">
-                  <div className="form-group label-floating is-empty">
-                    <Input
-                      onChange={(newValue) => this.updateNameInput(newValue, "levelOne")}
-                      text={this.state.rubric.levelOne}
-                      placeholder="e.g. Unsatisfactory, Beginner, Initial..."
-                      helpBlock="How would you describe the initial level of mastery of your Roadmap?"
+                <ExtendableList
+                  childCategory={"Competencies"}
+                  childCategorySingular={"Competency"}
+                  parentCategory={this.state.rubric.name}
+                  items={this.state.rubric.Competencies[0]}
+                  updateInputList={this.updateInputList}
+                  placeholder={"e.g. Testing (in CS), Inequalities (in Algebra)..."}
+                  helpBlock={"What categories or topics are prevalent in this subject?"}
+                  pIndex={0}
+                  addItemList={this.addItemList}
+                />
+
+                {this.state.rubric.Competencies[0].map((competency, index) => {
+                  return (
+                    <ExtendableList
+                      childCategory={"Skills"}
+                      childCategorySingular={"Skill"}
+                      parentCategory={this.state.rubric.Competencies[0][index]}
+                      items={this.state.rubric.Skills[index]}
+                      updateInputList={this.updateInputList}
+                      placeholder={"e.g. Body Language (when Speaking), Citing (when Writing)..."}
+                      helpBlock={"What is a skill to have to be knowledgeable in this competency?"}
+                      pIndex={index}
+                      addItemList={this.addItemList}
                     />
-                  </div>
-                </div>
-              </div>
-              <div className="row">
-                <label className="col-sm-2 label-on-left">Level 2</label>
-                <div className="col-sm-10">
-                  <div className="form-group label-floating is-empty">
-                    <Input
-                      onChange={(newValue) => this.updateNameInput(newValue, "levelTwo")}
-                      text={this.state.rubric.levelTwo}
-                      placeholder="e.g. Competant, Intermediate, Approaching..."
-                      helpBlock="How would you describe the second level of mastery of your Roadmap?"
+                  )
+                })}
+
+                {allSkills.map((skill, index) => {
+                  return (
+                    <ExtendableList
+                      childCategory={"Evaluations"}
+                      inputLabels={evalLabels}
+                      parentCategory={allSkills[index]}
+                      items={this.state.rubric.Evaluations[index]}
+                      updateInputList={this.updateInputList}
+                      placeholder={"e.g. Knowing common elements (Competant), Knowing all elements (Proficient)..."}
+                      helpBlock={"How would you evaluate this skill at this level?"}
+                      pIndex={index}
                     />
-                  </div>
-                </div>
-              </div>
-              <div className="row">
-                <label className="col-sm-2 label-on-left">Level 3</label>
-                <div className="col-sm-10">
-                  <div className="form-group label-floating is-empty">
-                    <Input
-                      onChange={(newValue) => this.updateNameInput(newValue, "levelThree")}
-                      text={this.state.rubric.levelThree}
-                      placeholder="e.g. Proficient, Advanced, Overtaking..."
-                      helpBlock="How would you describe the third level of mastery of your Roadmap?"
-                    />
-                  </div>
-                </div>
-              </div>
-              <div className="row">
-                <label className="col-sm-2 label-on-left">Level 4</label>
-                <div className="col-sm-10">
-                  <div className="form-group label-floating is-empty">
-                    <Input
-                      onChange={(newValue) => this.updateNameInput(newValue, "levelFour")}
-                      text={this.state.rubric.levelFour}
-                      placeholder="e.g. Professional, Expert, Innovating..."
-                      helpBlock="How would you describe the last level of mastery of your Roadmap?"
-                    />
-                  </div>
-                </div>
-              </div>
-              <ExtendableList
-                childCategory={"Competencies"}
-                parentCategory={this.state.rubric.name}
-                items={this.state.rubric.Competencies[0]}
-                updateInputList={this.updateInputList}
-                placeholder={"e.g. Testing (in CS), Inequalities (in Algebra)..."}
-                helpBlock={"What categories or topics are prevalent in this subject?"}
-                pIndex={0}
-                addItemList={this.addItemList}
-              />
-              {this.state.rubric.Competencies[0].map((competency, index) => {
-                return (
-                  <ExtendableList
-                    childCategory={"Skills"}
-                    parentCategory={this.state.rubric.Competencies[0][index]}
-                    items={this.state.rubric.Skills[index]}
-                    updateInputList={this.updateInputList}
-                    placeholder={"e.g. Body Language (when Speaking), Citing (when Writing)..."}
-                    helpBlock={"What is a skill to have to be knowledgeable in this competency?"}
-                    pIndex={index}
-                    addItemList={this.addItemList}
-                  />
-                )
-              })}
-              {allSkills.map((skill, index) => {
-                return (
-                  <ExtendableList
-                    childCategory={"Evaluations"}
-                    inputLabels={evalLabels}
-                    parentCategory={allSkills[index]}
-                    items={this.state.rubric.Evaluations[index]}
-                    updateInputList={this.updateInputList}
-                    placeholder={"e.g. Knowing common elements (Competant), Knowing all elements (Proficient)..."}
-                    helpBlock={"How would you evaluate this skill at this level?"}
-                    pIndex={index}
-                  />
-                )
-              })}
+                  )
+                })}
+
+                <button type="submit" className="btn btn-success pull-right"><i class="material-icons">done</i> Submit Rubric</button>
+                <div className="clearfix"></div>
+              </form>
+
             </div>
           </div>
         </div>

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -21,6 +21,7 @@ class RubricEdit extends Component {
       levelTwo: '',
       levelThree: '',
       levelFour: '',
+      components: [],
     }
   }
 
@@ -100,8 +101,8 @@ class RubricEdit extends Component {
                       onChange={(newValue) => this.updateNameInput(newValue, "name")}
                       placeholder="e.g. Code Review..."
                       autoFocus={true}
+                      helpBlock="What skillset does this roadmap assess/achieve?"
                     />
-                    <span className="help-block">What skillset does this roadmap assess/achieve?</span>
                   </div>
                 </div>
               </div>
@@ -134,8 +135,8 @@ class RubricEdit extends Component {
                       onChange={(newValue) => this.updateNameInput(newValue, "levelOne")}
                       text={this.state.rubric.levelOne}
                       placeholder="e.g. Unsatisfactory, Beginner, Initial..."
+                      helpBlock="How would you describe the initial level of mastery of your Roadmap?"
                     />
-                    <span className="help-block">How would you describe the initial level of mastery of your Roadmap?</span>
                   </div>
                 </div>
               </div>
@@ -147,8 +148,8 @@ class RubricEdit extends Component {
                       onChange={(newValue) => this.updateNameInput(newValue, "levelTwo")}
                       text={this.state.rubric.levelTwo}
                       placeholder="e.g. Competant, Intermediate, Approaching..."
+                      helpBlock="How would you describe the second level of mastery of your Roadmap?"
                     />
-                    <span className="help-block">How would you describe the second level of mastery of your Roadmap?</span>
                   </div>
                 </div>
               </div>
@@ -160,8 +161,8 @@ class RubricEdit extends Component {
                       onChange={(newValue) => this.updateNameInput(newValue, "levelThree")}
                       text={this.state.rubric.levelThree}
                       placeholder="e.g. Proficient, Advanced, Overtaking..."
+                      helpBlock="How would you describe the third level of mastery of your Roadmap?"
                     />
-                    <span className="help-block">How would you describe the third level of mastery of your Roadmap?</span>
                   </div>
                 </div>
               </div>
@@ -173,8 +174,8 @@ class RubricEdit extends Component {
                       onChange={(newValue) => this.updateNameInput(newValue, "levelFour")}
                       text={this.state.rubric.levelFour}
                       placeholder="e.g. Professional, Expert, Innovating..."
+                      helpBlock="How would you describe the last level of mastery of your Roadmap?"
                     />
-                    <span className="help-block">How would you describe the last level of mastery of your Roadmap?</span>
                   </div>
                 </div>
               </div>

--- a/src/components/RubricEdit.js
+++ b/src/components/RubricEdit.js
@@ -6,23 +6,37 @@ import { connect } from 'react-redux';
 import * as Actions from '../actions/rubric';
 import mixpanel from 'mixpanel-browser';
 import Input from './Input';
+import ExtendableList from './ExtendableList';
 
 class RubricEdit extends Component {
-
-  state = {
-    needsNewRubric: false,
-    nameInput: "",
-    rubric: {
-      id: '',
-      name: '',
-      description: '',
-      userId: '',
-      levelOne: '',
-      levelTwo: '',
-      levelThree: '',
-      levelFour: '',
-      components: [],
+  // Needed for this.state to correctly reference state when function is passed down
+  constructor(props) {
+    super(props)
+    this.state = {
+      needsNewRubric: false,
+      nameInput: "",
+      rubric: {
+        id: '',
+        name: '',
+        description: '',
+        userId: '',
+        levelOne: '',
+        levelTwo: '',
+        levelThree: '',
+        levelFour: '',
+        Competencies: [['']],
+        Skills: [['']],
+        Evaluations: [['', '', '', '']]
+      }
     }
+
+    this.componentWillMount = this.componentWillMount.bind(this)
+    this.componentDidMount = this.componentDidMount.bind(this)
+    this.redirect = this.redirect.bind(this)
+    this.goBack = this.goBack.bind(this)
+    this.updateNameInput = this.updateNameInput.bind(this)
+    this.updateInputList = this.updateInputList.bind(this)
+    this.addItemList = this.addItemList.bind(this)
   }
 
   // 1. Check to see if it is in 'edit' or 'new' mode
@@ -64,10 +78,21 @@ class RubricEdit extends Component {
   }
 
   updateNameInput(value, key) {
-    console.log(key, value)
     // console.log(this.props)
     // this.props.updateNameInput(e);
     this.setState({...this.state, rubric: {...this.state.rubric, [key]: value}})
+  }
+
+  updateInputList(value, key, pIndex, cIndex) {
+    const updatedList = [...this.state.rubric[key]]
+    updatedList[pIndex][cIndex] = value
+    this.setState({...this.state, rubric: {...this.state.rubric, [key]: updatedList}})
+  }
+
+  addItemList(key, pIndex) {
+    const updatedList = [...this.state.rubric[key]]
+    updatedList[pIndex].push('')
+    this.setState({...this.state, rubric: {...this.state.rubric, [key]: updatedList}})
   }
 
   render() {
@@ -78,7 +103,7 @@ class RubricEdit extends Component {
     const lastName = localStorage.getItem('lastName')
     return (
       <div className="col-sm-10 col-md-9 col-lg-8">
-        {this.redirect(isFetching, needsNewRubric, userId, id)}
+        {/* {this.redirect(isFetching, needsNewRubric, userId, id)} */}
         <button onClick={this.goBack.bind(this)} style={{padding: '0'}} className="btn btn-lg btn-info btn-round btn-simple">
           <i className="material-icons">arrow_back_ios</i> back
         </button>
@@ -179,10 +204,16 @@ class RubricEdit extends Component {
                   </div>
                 </div>
               </div>
-              <div>&nbsp;</div>
-
-
-
+              <ExtendableList
+                childCategory={"Competencies"}
+                parentCategory={this.state.rubric.name}
+                items={this.state.rubric.Competencies[0]}
+                updateInputList={this.updateInputList}
+                placeholder={"e.g. Testing (in CS), Inequalities (in Algebra)..."}
+                helpBlock={"What categories or topics are prevalent in this subject?"}
+                pIndex={0}
+                addItemList={this.addItemList}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Added `ExtendableList.js` component
- Updated `RubricEdit.js` component
- Added state in the local `RubricEdit.js` component
- Added server requests in the local `RubricEdit.js` component

TODO:
- [ ] Move state to Redux store
- [ ] Refactor the code to render the components as a wizard
- [ ] Allow the RubricEdit form to be used as an edit form as well
- [ ] Add errors if parts of the rubric aren't filled out and user tries to submit
- [ ] Allows parts of the rubric, and their children, to be deleted with a confirmation box
- [ ] Add more description as to what each part is for in a rubric
- [ ] Auto save with Debouce